### PR TITLE
[FP-1058] Fix initialization issue on multiple tags

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -530,11 +530,7 @@ ___WEB_PERMISSIONS___
             "listItem": [
               {
                 "type": 1,
-                "string": "https://perfalytics.com/*,"
-              },
-              {
-                "type": 1,
-                "string": "https://ci-test-sites.s3-us-west-2.amazonaws.com/fp001.local/*"
+                "string": "https://perfalytics.com/*"
               }
             ]
           }

--- a/template.tpl
+++ b/template.tpl
@@ -442,7 +442,7 @@ const track = (eventName, props, options) => {
    });
 };
 
-const JS_URL = "https://ci-test-sites.s3-us-west-2.amazonaws.com/fp001.local/fp-gtm-proxy/7.js";
+const JS_URL = "https://perfalytics.com/static/js/freshpaint-jslib-snippet-gtm.js";
 
 
 if (!callFreshpaintProxy("isLoaded")) {


### PR DESCRIPTION
summary of changes:
- interface Freshpaint GTM Proxy instead of directly with `window.freshpaint`. This avoids a bunch of initialization issues and simplifies the template code.
- Add support for different freshpaint environment IDs in different tags.
  - if an environment ID is provided in the tag then we'll send events to that environment.
  -  if environment ID is not provided in the tag, freshpaint must be instantiated in the page (either directly by including the freshpaint snippet, or by the freshpaint init GTM tag). We'll use that environment to send events. 
- re-add support for basic freshpaint tags like `track` and `identify` 