### PR TITLE
FP-1041 Add Google Ads support

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1394,7 +1394,7 @@ const processBingEvent = () => {
 };
 
 const processGoogleAdsEvent = () => {
-  const options = generateOptions("Google Ads");
+  const options = generateOptions("Google AdWords New");
 
   // make track call
 

--- a/template.tpl
+++ b/template.tpl
@@ -71,7 +71,11 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "bingAdsEvent",
         "displayValue": "Microsoft Advertising Universal Event Tracking (Bing Ads)"
-      }
+      },
+      {
+        "value": "googleAdsEvent",
+        "displayValue": "Google Ads Conversion Event"
+      },
     ],
     "simpleValueType": true
   },
@@ -89,6 +93,96 @@ ___TEMPLATE_PARAMETERS___
       {
         "paramName": "tagType",
         "paramValue": "ga4Event",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "googleAdsConversionId",
+    "displayName": "Conversion ID",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "track",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "googleAdsConversionLabel",
+    "displayName": "Conversion Label",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "track",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "googleAdsConversionValue",
+    "displayName": "Conversion Value",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "track",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "googleAdsTransactionId",
+    "displayName": "Transaction ID",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "track",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "googleAdsCurrencyCode",
+    "displayName": "Currency Code",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "track",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsEvent",
         "type": "EQUALS"
       }
     ]
@@ -1118,6 +1212,8 @@ const processEvent = () => {
     processTwitterEvent();
   } else if (data.tagType === "bingAdsEvent") {
     processBingEvent();
+  } else if (data.tagType === "googleAdsEvent") {
+    processGoogleAdsEvent();
   }
 
   data.gtmOnSuccess();
@@ -1277,6 +1373,9 @@ const processBingEvent = () => {
   } 
   
   track(eventName, props, options);
+};
+
+const processGoogleAdsEvent = () => {
 };
 
 const callFreshpaintProxy = (cmdName, args) => {

--- a/template.tpl
+++ b/template.tpl
@@ -99,8 +99,8 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "TEXT",
-    "name": "googleAdsConversionId",
-    "displayName": "Conversion ID",
+    "name": "googleAdseventName",
+    "displayName": "Event Name",
     "simpleValueType": true,
     "enablingConditions": [
       {
@@ -135,8 +135,26 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "TEXT",
+    "name": "googleAdsConversionId",
+    "displayName": "Conversion ID (optional)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "track",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
     "name": "googleAdsConversionValue",
-    "displayName": "Conversion Value",
+    "displayName": "Conversion Value (optional)",
     "simpleValueType": true,
     "enablingConditions": [
       {
@@ -154,7 +172,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "TEXT",
     "name": "googleAdsTransactionId",
-    "displayName": "Transaction ID",
+    "displayName": "Transaction ID (optional)",
     "simpleValueType": true,
     "enablingConditions": [
       {
@@ -172,7 +190,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "TEXT",
     "name": "googleAdsCurrencyCode",
-    "displayName": "Currency Code",
+    "displayName": "Currency Code (optional)",
     "simpleValueType": true,
     "enablingConditions": [
       {
@@ -1376,6 +1394,32 @@ const processBingEvent = () => {
 };
 
 const processGoogleAdsEvent = () => {
+  const options = generateOptions("Google Ads");
+
+  // make track call
+
+  if (data.googleAdseventName && data.googleAdsConversionLabel) {
+    const props = parsePropsTable(data.eventProps || []);
+
+    props["conversion_label"] = data.googleAdsConversion_label;
+
+    // conversion_id is optional override to freshpaint-configured one for destination
+    if (data.googleAdsConversionId) {
+        props["conversion_id"] = data.googleAdsConversionId;
+    }
+
+    if (data.googleAdsConversionValue) {
+        props["value"] = data.googleAdsConversionValue;
+    }
+    if (data.googleAdsTransactionId) {
+        props["transaction_id"] = data.googleAdsTransactionId;
+    }
+    if (data.googleAdsCurrencyCode) {
+        props["currency"] = data.googleAdsCurrencyCode;
+    }
+
+    track(data.googleAdseventName, props, options);
+  }
 };
 
 const callFreshpaintProxy = (cmdName, args) => {

--- a/template.tpl
+++ b/template.tpl
@@ -1401,7 +1401,7 @@ const processGoogleAdsEvent = () => {
   if (data.googleAdseventName && data.googleAdsConversionLabel) {
     const props = parsePropsTable(data.eventProps || []);
 
-    props["conversion_label"] = data.googleAdsConversion_label;
+    props["conversion_label"] = data.googleAdsConversionLabel;
 
     // conversion_id is optional override to freshpaint-configured one for destination
     if (data.googleAdsConversionId) {


### PR DESCRIPTION
## Purpose
Provide Freshpaint-GTM-template support for Google Ads.

Supports all fields the Native-GTM Google ads type supports.

Tested E2E with Google Ads (Freshpaint account), observed conversion value posted.