### PR TITLE
FP-1127 fix GTM GA4 identify to not clobber userid

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1216,7 +1216,7 @@ const processBasicOrGA4Event = (isGA4Event) => {
 
   if (data.ga4UserProperties) {
     const props = parsePropsTable(data.ga4UserProperties || []);
-    identify("", props, options);
+    identify(props);
   }
 
   if (data.ga4EventName) {

--- a/template.tpl
+++ b/template.tpl
@@ -1216,7 +1216,7 @@ const processBasicOrGA4Event = (isGA4Event) => {
 
   if (data.ga4UserProperties) {
     const props = parsePropsTable(data.ga4UserProperties || []);
-    identify(props);
+    identify(undefined, props, options);
   }
 
   if (data.ga4EventName) {


### PR DESCRIPTION
GTM GA4 (both native and Freshpaint versions) supports optional user props

When these are specified, this call is currently being used:

`
identify("", props, options);
`
* This causes a previously set $user_id to get clobbered with the new value "".

The corrected syntax is below, which preserves any previously-set identity:

`identify(props);`;

* The options arg is removed, since it seems to have no effect when used with identify and the single props arg.