### PR TITLE
FP-1152 remove extraneous comma

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -573,7 +573,7 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "userDefined",
         "displayValue": "Define your own"
-      },
+      }
     ],
     "simpleValueType": true,
     "enablingConditions": [


### PR DESCRIPTION
GTM imported it ok, but caused migration script to falsely flag a template change when there is none