### PR TITLE
FP-1279 Add theTradeDesk type, fix identify, fix fb default standardEvent

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1488,11 +1488,22 @@ const generateOptions = (integration) => {
 };
 
 const processInit = () => {
+  // Init handled upstream
   data.gtmOnSuccess();
 };
 
 const processTrack = () => {
-  data.gtmOnSuccess();
+  const options = {};
+
+  if (data.commonEventName) {
+    const props = parseSimpleTable(data.commonEventProperties || []);
+    track(data.commonEventName, props, options);
+
+    data.gtmOnSuccess();
+  } else {
+      log("ERROR: Freshpaint Track GTM Template missing eventName");
+      data.gtmOnFailure();
+  }
 };
 
 const processIdentify = () => {
@@ -1709,7 +1720,7 @@ const processTheTradeDeskEvent = () => {
     }
 
     if (data.theTradeDeskEventName) {
-      props.event_name = data.theTradeDeskEventName;
+      props.ttd_event_name = data.theTradeDeskEventName;
     }
 
     if (data.theTradeDeskValue) {

--- a/template.tpl
+++ b/template.tpl
@@ -1153,10 +1153,10 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
-    "type": "SELECT",
+    "type": "RADIO",
     "name": "theTradeDeskTrackerOrUPixel",
-    "displayName": "Event Tracker ID / Universal Pixel ID",
-    "selectItems": [
+    "displayName": "Use Event Tracker ID vs. Universal Pixel ID",
+    "radioItems": [
       {
         "value": "tracker_id",
         "displayValue": "Event Tracker ID"
@@ -1166,15 +1166,13 @@ ___TEMPLATE_PARAMETERS___
         "displayValue": "Universal Pixel ID"
       }
     ],
-    "simpleValueType": true,
-    "defaultValue": "tracker_id",
     "enablingConditions": [
       {
         "paramName": "tagType",
         "paramValue": "theTradeDeskEvent",
         "type": "EQUALS"
       }
-    ]
+    ],
   },
   {
     "type": "TEXT",
@@ -1248,7 +1246,7 @@ ___TEMPLATE_PARAMETERS___
         "displayValue": "wishlistitem"
       }
     ],
-    "defaultValue": "NONEXISTENT",
+    "notSetText": "-",
     "enablingConditions": [
       {
         "paramName": "tagType",

--- a/template.tpl
+++ b/template.tpl
@@ -1150,15 +1150,15 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "SELECT",
     "name": "theTradeDeskTrackerOrUPixel",
-    "displayName": "tracker_id / upixel_id",
+    "displayName": "Event Tracker ID / Universal Pixel ID",
     "selectItems": [
       {
         "value": "tracker_id",
-        "displayValue": "tracker_id"
+        "displayValue": "Event Tracker ID"
       },
       {
         "value": "upixel_id",
-        "displayValue": "upixel_id"
+        "displayValue": "Universal Pixel ID"
       }
     ],
     "simpleValueType": true,
@@ -1174,7 +1174,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "TEXT",
     "name": "theTradeDeskTrackerOrUPixelIDValue",
-    "displayName": "tracker_id / upixel_id Value",
+    "displayName": "Event Tracker ID / Universal Pixel ID Value",
     "simpleValueType": true,
     "enablingConditions": [
       {
@@ -1192,7 +1192,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "SELECT",
     "name": "theTradeDeskEventName",
-    "displayName": "Event Name (optional)",
+    "displayName": "Event Name (recommended if using Event Tracker ID)",
     "selectItems": [
       {
         "value": "addtocart",

--- a/template.tpl
+++ b/template.tpl
@@ -91,7 +91,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "TEXT",
     "name": "commonEventName",
-    "displayName": "Event Name",
+    "displayName": "Freshpaint Event Name",
     "simpleValueType": true,
     "valueValidators": [
       {
@@ -339,7 +339,7 @@ ___TEMPLATE_PARAMETERS___
               }
             ],
             "simpleValueType": true,
-            "defaultValue": "Pageview"
+            "defaultValue": "PageView"
           }
         ]
       },
@@ -1197,7 +1197,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "SELECT",
     "name": "theTradeDeskEventName",
-    "displayName": "Event Name (recommended if using Event Tracker ID)",
+    "displayName": "Event Name",
     "selectItems": [
       {
         "value": "addtocart",
@@ -1248,9 +1248,7 @@ ___TEMPLATE_PARAMETERS___
         "displayValue": "wishlistitem"
       }
     ],
-    "simpleValueType": true,
-    "notSetText": "",
-    "defaultValue": "",
+    "defaultValue": "NONEXISTENT",
     "enablingConditions": [
       {
         "paramName": "tagType",

--- a/template.tpl
+++ b/template.tpl
@@ -113,6 +113,11 @@ ___TEMPLATE_PARAMETERS___
         "paramName": "tagType",
         "paramValue": "googleAdsEvent",
         "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
       }
     ]
   },

--- a/template.tpl
+++ b/template.tpl
@@ -80,6 +80,10 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "googleAdsEvent",
         "displayValue": "Google Ads"
+      },
+      {
+        "value": "theTradeDeskEvent",
+        "displayValue": "theTradeDesk"
       }
     ],
     "simpleValueType": true
@@ -315,6 +319,10 @@ ___TEMPLATE_PARAMETERS___
               {
                 "value": "StartTrial",
                 "displayValue": "StartTrial"
+              },
+              {
+                "value": "SubmitApplication",
+                "displayValue": "SubmitApplication"
               },
               {
                 "value": "Subscribe",
@@ -1135,6 +1143,240 @@ ___TEMPLATE_PARAMETERS___
       {
         "paramName": "tagType",
         "paramValue": "bingAdsEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "SELECT",
+    "name": "theTradeDeskTrackerOrUPixel",
+    "displayName": "tracker_id / upixel_id",
+    "selectItems": [
+      {
+        "value": "tracker_id",
+        "displayValue": "tracker_id"
+      },
+      {
+        "value": "upixel_id",
+        "displayValue": "upixel_id"
+      }
+    ],
+    "simpleValueType": true,
+    "defaultValue": "tracker_id",
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "theTradeDeskTrackerOrUPixelIDValue",
+    "displayName": "tracker_id / upixel_id Value",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      }
+    ],
+    "valueValidators": [
+      {
+        "type": "NON_EMPTY"
+      }
+    ]
+  },
+  {
+    "type": "SELECT",
+    "name": "theTradeDeskEventName",
+    "displayName": "Event Name (optional)",
+    "selectItems": [
+      {
+        "value": "addtocart",
+        "displayValue": "addtocart"
+      },
+      {
+        "value": "purchase",
+        "displayValue": "purchase"
+      },
+      {
+        "value": "viewitem",
+        "displayValue": "viewitem"
+      },
+      {
+        "value": "searchitem",
+        "displayValue": "searchitem"
+      },
+      {
+        "value": "searchcategory",
+        "displayValue": "searchcategory"
+      },
+      {
+        "value": "login",
+        "displayValue": "login"
+      },
+      {
+        "value": "messagebusiness",
+        "displayValue": "messagebusiness"
+      },
+      {
+        "value": "direction",
+        "displayValue": "direction"
+      },
+      {
+        "value": "startcheckout",
+        "displayValue": "startcheckout"
+      },
+      {
+        "value": "viewcart",
+        "displayValue": "viewcart"
+      },
+      {
+        "value": "sitevisit",
+        "displayValue": "sitevisit"
+      },
+      {
+        "value": "wishlistitem",
+        "displayValue": "wishlistitem"
+      }
+    ],
+    "simpleValueType": true,
+    "notSetText": "",
+    "defaultValue": "",
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "theTradeDeskValue",
+    "displayName": "value (required only for purchase events)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "theTradeDeskCurrency",
+    "displayName": "currency (optional)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "theTradeDeskOrderId",
+    "displayName": "order_id (optional)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "theTradeDeskItems",
+    "displayName": "items (optional object array)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "PARAM_TABLE",
+    "name": "theTradeDeskTDEventParameters",
+    "displayName": "td1 - td10 properties (optional)",
+    "paramTableColumns": [
+      {
+        "param": {
+          "type": "SELECT",
+          "name": "param_table_key_column",
+          "displayName": "property",
+          "macrosInSelect": false,
+          "selectItems": [
+            {
+              "value": "td1",
+              "displayValue": "td1"
+            },
+            {
+              "value": "td2",
+              "displayValue": "td2"
+            },
+            {
+              "value": "td3",
+              "displayValue": "td3"
+            },
+            {
+              "value": "td4",
+              "displayValue": "td4"
+            },
+            {
+              "value": "td5",
+              "displayValue": "td5"
+            },
+            {
+              "value": "td6",
+              "displayValue": "td6"
+            },
+            {
+              "value": "td7",
+              "displayValue": "td7"
+            },
+            {
+              "value": "td8",
+              "displayValue": "td8"
+            },
+            {
+              "value": "td9",
+              "displayValue": "td9"
+            },
+            {
+              "value": "td10",
+              "displayValue": "td10"
+            }
+          ],
+          "simpleValueType": true
+        },
+        "isUnique": true
+      },
+      {
+        "param": {
+          "type": "TEXT",
+          "name": "param_table_value_column",
+          "displayName": "Value",
+          "simpleValueType": true
+        },
+        "isUnique": false
+      }
+    ],
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
         "type": "EQUALS"
       }
     ]


### PR DESCRIPTION
## Summary
* theTradeDesk type added
  * template UI
  * js handler (track)
* fixed pre-existing issue with parsing a PARAM_TABLE (was not working for twitter ads, now fixed)
* fixed pre-existing facebook issue where the default standard event, pageview, was not selected properly
* fixed pre-existing facebook issue where SubmitApplication was missing from standard eventnames list
* fixed pre-existing identify issue where userid not prompted for
* changed commonEventName prop display name to 'Freshpaint Event", to differentiate it for theTradeDesk where the ttd-specific event name is optional, and often omitted
* refactored to use data.gtmOnSuccess() and gtmOnFailure() consistently, with a log message preceding every gtmOnFailure() 

## Testing notes
* Used a local site with GTM tag installed for fptest GTM container
* Verified payload by inspecting in chrome dev tools, from fbptest test theTradeDesk tags
* Verified ingest by observing a server-side delivery trace

## Other notes
* These changes are bundled together in one PR because we like to minimize how often we update the public template
* The first cut of the GTM migration script supporting theTradeDesk will treat it as an experimental destination, minimizing the chance of premature migrations of theTradeDesk tags