### PR TITLE
FP-1289 gtm template for stackadapt

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1785,9 +1785,21 @@ const processTheTradeDeskEvent = () => {
     }
 
     if (data.theTradeDeskItems) {
-      props.items = data.theTradeDeskItems;
+      props.items = JSON.parse(data.theTradeDeskItems);
+      if (!props.items) {
+        log("ERROR: Freshpaint theTradeDesk GTM Template parsing items json: " + data.theTradeDeskItems);
+
+        data.gtmOnFailure();
+        return;
+      }
     }
+
     track(data.commonEventName, props, options);
+
+    data.gtmOnSuccess();
+  } else {
+    log("ERROR: Freshpaint theTradeDesk GTM Template missing eventNme and / or trackerOrUPixelIDValue");
+    data.gtmOnFailure();
   }
 };
 

--- a/template.tpl
+++ b/template.tpl
@@ -84,6 +84,10 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "theTradeDeskEvent",
         "displayValue": "theTradeDesk"
+      },
+      {
+        "value": "stackAdaptEvent",
+        "displayValue": "StackAdapt"
       }
     ],
     "defaultValue": "ga4Event",
@@ -119,67 +123,10 @@ ___TEMPLATE_PARAMETERS___
         "paramName": "tagType",
         "paramValue": "theTradeDeskEvent",
         "type": "EQUALS"
-      }
-    ]
-  },
-  {
-    "type": "SIMPLE_TABLE",
-    "name": "commonEventProperties",
-    "displayName": "Event Properties",
-    "simpleTableColumns": [
-      {
-        "defaultValue": "",
-        "displayName": "Property Name",
-        "name": "name",
-        "type": "TEXT"
-      },
-      {
-        "defaultValue": "",
-        "displayName": "Property Value",
-        "name": "value",
-        "type": "TEXT"
-      }
-    ],
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "track",
-        "type": "EQUALS"
       },
       {
         "paramName": "tagType",
-        "paramValue": "ga4Event",
-        "type": "EQUALS"
-      }
-    ]
-  },
-  {
-    "type": "SIMPLE_TABLE",
-    "name": "commonUserProperties",
-    "displayName": "User Properties",
-    "simpleTableColumns": [
-      {
-        "defaultValue": "",
-        "displayName": "Property Name",
-        "name": "name",
-        "type": "TEXT"
-      },
-      {
-        "defaultValue": "",
-        "displayName": "Property Value",
-        "name": "value",
-        "type": "TEXT"
-      }
-    ],
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "identify",
-        "type": "EQUALS"
-      },
-      {
-        "paramName": "tagType",
-        "paramValue": "ga4Event",
+        "paramValue": "stackAdaptEvent",
         "type": "EQUALS"
       }
     ]
@@ -1395,6 +1342,91 @@ ___TEMPLATE_PARAMETERS___
         "type": "EQUALS"
       }
     ]
+  },
+  {
+    "type": "TEXT",
+    "name": "stackAdaptConversionEventID",
+    "displayName": "StackAdapt Conversion Event Unique ID",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "stackAdaptEvent",
+        "type": "EQUALS"
+      }
+    ],
+    "valueValidators": [
+      {
+        "type": "NON_EMPTY"
+      }
+    ]
+  },
+  {
+    "type": "SIMPLE_TABLE",
+    "name": "commonEventProperties",
+    "displayName": "Event Properties",
+    "simpleTableColumns": [
+      {
+        "defaultValue": "",
+        "displayName": "Property Name",
+        "name": "name",
+        "type": "TEXT"
+      },
+      {
+        "defaultValue": "",
+        "displayName": "Property Value",
+        "name": "value",
+        "type": "TEXT"
+      }
+    ],
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "track",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "ga4Event",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "stackAdaptEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "SIMPLE_TABLE",
+    "name": "commonUserProperties",
+    "displayName": "User Properties",
+    "simpleTableColumns": [
+      {
+        "defaultValue": "",
+        "displayName": "Property Name",
+        "name": "name",
+        "type": "TEXT"
+      },
+      {
+        "defaultValue": "",
+        "displayName": "Property Value",
+        "name": "value",
+        "type": "TEXT"
+      }
+    ],
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "identify",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "ga4Event",
+        "type": "EQUALS"
+      }
+    ]
   }
 ]
 
@@ -1470,6 +1502,8 @@ const processEvent = () => {
     processGoogleAdsEvent();
   } else if (data.tagType === "theTradeDeskEvent") {
     processTheTradeDeskEvent();
+  } else if (data.tagType === "stackAdaptEvent") {
+    processStackAdaptEvent();
   } else {
     log("ERROR: Freshpaint GTM Template unsupported tagType '" + data.tagType + "'");
     data.gtmOnFailure();
@@ -1754,51 +1788,19 @@ const processTheTradeDeskEvent = () => {
   }
 };
 
-const processTheTradeDeskEvent = () => {
-  const options = generateOptions("theTradeDesk");
+const processStackAdaptEvent = () => {
+  const options = generateOptions("StackAdapt");
 
-  // make track call
+  if (data.commonEventName && data.stackAdaptConversionEventID) {
+    const props = parseSimpleTable(data.commonEventProperties || []);
 
-  if (data.commonEventName && data.theTradeDeskTrackerOrUPixelIDValue) {
-    const props = parseParamTable(data.theTradeDeskTDEventParameters || []);
-
-    if (data.theTradeDeskTrackerOrUPixel === "tracker_id") {
-      props.tracker_id = data.theTradeDeskTrackerOrUPixelIDValue;
-    } else {
-      props.upixel_id = data.theTradeDeskTrackerOrUPixelIDValue;
-    }
-
-    if (data.theTradeDeskEventName) {
-      props.event_name = data.theTradeDeskEventName;
-    }
-
-    if (data.theTradeDeskValue) {
-      props.value = data.theTradeDeskValue;
-    }
-
-    if (data.theTradeDeskCurrency) {
-      props.currency = data.theTradeDeskCurrency;
-    }
-
-    if (data.theTradeDeskOrderId) {
-      props.order_id = data.theTradeDeskOrderId;
-    }
-
-    if (data.theTradeDeskItems) {
-      props.items = JSON.parse(data.theTradeDeskItems);
-      if (!props.items) {
-        log("ERROR: Freshpaint theTradeDesk GTM Template parsing items json: " + data.theTradeDeskItems);
-
-        data.gtmOnFailure();
-        return;
-      }
-    }
+    props.conversion_id = data.stackAdaptConversionEventID;
 
     track(data.commonEventName, props, options);
 
     data.gtmOnSuccess();
   } else {
-    log("ERROR: Freshpaint theTradeDesk GTM Template missing eventNme and / or trackerOrUPixelIDValue");
+    log("ERROR: Freshpaint StackAdapt GTM Template missing eventName and / or stackAdaptConversionEventID");
     data.gtmOnFailure();
   }
 };

--- a/template.tpl
+++ b/template.tpl
@@ -1754,6 +1754,43 @@ const processTheTradeDeskEvent = () => {
   }
 };
 
+const processTheTradeDeskEvent = () => {
+  const options = generateOptions("theTradeDesk");
+
+  // make track call
+
+  if (data.commonEventName && data.theTradeDeskTrackerOrUPixelIDValue) {
+    const props = parseParamTable(data.theTradeDeskTDEventParameters || []);
+
+    if (data.theTradeDeskTrackerOrUPixel === "tracker_id") {
+      props.tracker_id = data.theTradeDeskTrackerOrUPixelIDValue;
+    } else {
+      props.upixel_id = data.theTradeDeskTrackerOrUPixelIDValue;
+    }
+
+    if (data.theTradeDeskEventName) {
+      props.event_name = data.theTradeDeskEventName;
+    }
+
+    if (data.theTradeDeskValue) {
+      props.value = data.theTradeDeskValue;
+    }
+
+    if (data.theTradeDeskCurrency) {
+      props.currency = data.theTradeDeskCurrency;
+    }
+
+    if (data.theTradeDeskOrderId) {
+      props.order_id = data.theTradeDeskOrderId;
+    }
+
+    if (data.theTradeDeskItems) {
+      props.items = data.theTradeDeskItems;
+    }
+    track(data.commonEventName, props, options);
+  }
+};
+
 const callFreshpaintProxy = (cmdName, args) => {
   return callInWindow("_freshpaint_gtm_proxy", cmdName, args);
 };


### PR DESCRIPTION
This adds a stackadapt event type to our GTM template

<img width="2168" alt="Screenshot 2023-08-08 at 10 08 09" src="https://github.com/freshpaint-io/freshpaint-gtm-template/assets/7072770/45e36b26-572b-4a67-8bbc-f4a2cd3711bb">


Resulted in the following event in snowflake:
```
{
  "event": "stack adapt test",
  "properties": {
    "$browser": "Chrome",
    "$browser_version": 114,
    "$current_url": "https://gtm-msr.appspot.com/render2?id=GTM-WP69WFQ5",
    "$device_id": "189d58cd85637-0f406e788faea1-26031d51-100200-189d58cd8576e",
    "$device_type": "Desktop",
    "$eventDefProps": {},
    "$event_name": "stack adapt test",
    "$gtm": true,
    "$host": "gtm-msr.appspot.com",
    "$initial_referrer": "https://gtm-msr.appspot.com/render?id=GTM-WP69WFQ5",
    "$initial_referring_domain": "gtm-msr.appspot.com",
    "$insert_id": "qmvle3b2j486ffwu",
    "$ip": "66.102.8.131",
    "$lib_version": "1.3.0",
    "$options": {
      "integrations": {
        "All": false,
        "StackAdapt": true
      }
    },
    "$os": "Windows",
    "$pathname": "/render2",
    "$referrer": "https://gtm-msr.appspot.com/render?id=GTM-WP69WFQ5",
    "$referring_domain": "gtm-msr.appspot.com",
    "$screen_height": 768,
    "$screen_width": 1366,
    "$session_id": "189d58cd85867-01b01d6f141c68-26031d51-100200-189d58cd8596e",
    "$title": "gtm-msr",
    "$user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
    "conversion_id": "test",
    "distinct_id": "189d58cd85637-0f406e788faea1-26031d51-100200-189d58cd8576e",
    "mp_lib": "web",
    "time": 1691504924.762,
    "token": "abf05da9-5da1-446b-9027-3944255448d8"
  }
}
```