### PR TITLE
FP-1306 disable theTradeDesk upixel_id option

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1136,14 +1136,11 @@ ___TEMPLATE_PARAMETERS___
     "type": "RADIO",
     "name": "theTradeDeskTrackerOrUPixel",
     "displayName": "Use Event Tracker ID vs. Universal Pixel ID",
+    "help": "Universal Pixel ID not currently supported",
     "radioItems": [
       {
         "value": "tracker_id",
         "displayValue": "Event Tracker ID"
-      },
-      {
-        "value": "upixel_id",
-        "displayValue": "Universal Pixel ID"
       }
     ],
     "enablingConditions": [
@@ -1158,6 +1155,7 @@ ___TEMPLATE_PARAMETERS___
     "type": "TEXT",
     "name": "theTradeDeskTrackerOrUPixelIDValue",
     "displayName": "Event Tracker ID / Universal Pixel ID Value",
+    "help": "Universal Pixel ID not currently supported",
     "simpleValueType": true,
     "enablingConditions": [
       {
@@ -1773,6 +1771,7 @@ const processTheTradeDeskEvent = () => {
     if (data.theTradeDeskTrackerOrUPixel === "tracker_id") {
       props.tracker_id = data.theTradeDeskTrackerOrUPixelIDValue;
     } else {
+      // Not currently exercised since upixel_id is disabled from UI control, for now
       props.upixel_id = data.theTradeDeskTrackerOrUPixelIDValue;
     }
 

--- a/template.tpl
+++ b/template.tpl
@@ -1173,7 +1173,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "SELECT",
     "name": "theTradeDeskEventName",
-    "displayName": "Event Name",
+    "displayName": "Event Name (optional)",
     "selectItems": [
       {
         "value": "addtocart",


### PR DESCRIPTION
## Summary
* Template originally written to support both tracker_id and upixel_id
* In our current scope and pilot, we plan to support only tracker_id, therefore removing upixel_id as a selectable option for now