### PR TITLE
[FP-2094] Change floodlight param table column names

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -555,7 +555,7 @@ ___TEMPLATE_PARAMETERS___
       {
         "param": {
           "type": "SELECT",
-          "name": "param_table_key_column",
+          "name": "key",
           "displayName": "Key",
           "macrosInSelect": false,
           "selectItems": [
@@ -647,7 +647,7 @@ ___TEMPLATE_PARAMETERS___
       {
         "param": {
           "type": "TEXT",
-          "name": "param_table_value_column",
+          "name": "value",
           "displayName": "Value",
           "simpleValueType": true
         },


### PR DESCRIPTION
I originally copied the column names from the twitter param_table, but apparently they have to match the native floodlight tag column names for the migration script to work.