### PR TITLE
CA-11 Add updated multi-config support for Facebook cAPI

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1991,15 +1991,16 @@ const integrations = {
 
   let instanceNamesToUse;
   if (instanceNames) {
-    instanceNamesToUse = instanceNames.replaceAll(' ', '');
+    instanceNamesToUse = instanceNames.trim();
   }
 
   if (instanceNamesToUse) {
-    instanceNamesToUse = instanceNamesToUse.split(",");
+    instanceNamesToUse = instanceNamesToUse.split(',');
     for (let i = 0; i < instanceNamesToUse.length; i++) {
       const instanceDelimiter = '::';
-      integrations[integration + instanceDelimiter + instanceNamesToUse[i]] = true;
+      integrations[integration + instanceDelimiter + instanceNamesToUse[i].toString()] = true;
     }
+
     return {
       integrations: integrations,
     };

--- a/template.tpl
+++ b/template.tpl
@@ -1984,6 +1984,32 @@ const generateOptions = (integration) => {
   };
 };
 
+const generateOptionsFromInstances = (integration, instanceNames) => {
+const integrations = {
+    All: false,
+  };
+
+  let instanceNamesToUse
+  if (instanceNames) {
+    instanceNamesToUse = instanceNames.replaceAll(' ', '');
+  }
+
+  if (instanceNamesToUse) {
+    instanceNamesToUse = instanceNamesToUse.split(",");
+    for (let i = 0; i < instanceNamesToUse.length; i++) {
+      const instanceDelimiter = '::';
+      integrations[integration + instanceDelimiter + instanceNamesToUse[i]] = true;
+
+      return {
+        integrations: integrations,
+      };
+    }
+  } else {
+    return generateOptions(integration);
+  }
+};
+
+
 const processInit = () => {
   // Init handled upstream
   data.gtmOnSuccess();
@@ -2055,7 +2081,7 @@ const mergeObj = (obj, obj2) => {
 };
 
 const processFBPixelEvent = () => {
-  const options = generateOptions("Facebook Conversions API");
+  let options = generateOptions("Facebook Conversions API");
 
   const eventName =
     data.fbEventName === "custom" ?
@@ -2070,8 +2096,10 @@ const processFBPixelEvent = () => {
     getType(data.fbObjectPropertiesFromVariable) === "object" ? 
       data.fbObjectPropertiesFromVariable : {};
   const mergedObjectProps = mergeObj(objectPropsFromVar, objectProps);
-  
-  if (data.commonDestConfigNames) {
+
+  if (data.fbInstanceNames) {
+    options = generateOptionsFromInstances("Facebook Conversions API", data.fbInstanceNames);
+  } else if (data.commonDestConfigNames) {
     mergedObjectProps.dest_config_names = data.commonDestConfigNames;
   }
 

--- a/template.tpl
+++ b/template.tpl
@@ -1989,7 +1989,7 @@ const integrations = {
     All: false,
   };
 
-  let instanceNamesToUse
+  let instanceNamesToUse;
   if (instanceNames) {
     instanceNamesToUse = instanceNames.replaceAll(' ', '');
   }
@@ -1999,11 +1999,10 @@ const integrations = {
     for (let i = 0; i < instanceNamesToUse.length; i++) {
       const instanceDelimiter = '::';
       integrations[integration + instanceDelimiter + instanceNamesToUse[i]] = true;
-
-      return {
-        integrations: integrations,
-      };
     }
+    return {
+      integrations: integrations,
+    };
   } else {
     return generateOptions(integration);
   }

--- a/template.tpl
+++ b/template.tpl
@@ -123,6 +123,48 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "TEXT",
+    "name": "ga4InstanceNames",
+    "displayName": "Specific Measurement ID(s) (optional)",
+    "help": "If multiple Measurement IDs are configured for the Google Analytics 4 (Proxy), specify one or more specific Measurement IDs to deliver to (otherwise, this event will be delivered to all configured Measurement IDs)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "ga4Event",
+        "type": "EQUALS"
+      },
+    ],
+  },
+  {
+    "type": "TEXT",
+    "name": "fbInstanceNames",
+    "displayName": "Specific Pixel ID(s) (optional)",
+    "help": "If multiple Pixel IDs are configured for the Facebook Conversions API, specify one or more specific Pixel IDs to deliver to (otherwise, this event will be delivered to all configured Pixel IDs)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "fbPixelEvent",
+        "type": "EQUALS"
+      },
+    ],
+  },
+  {
+    "type": "TEXT",
+    "name": "theTradeDeskInstanceNames",
+    "displayName": "Specific Advertiser ID(s) (optional)",
+    "help": "If multiple Advertiser IDs are configured for theTradeDesk, specify one or more specific Advertiser IDs to deliver to (otherwise, this event will be delivered to all configured Advertiser IDs)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      },
+    ],
+  },
+  {
+    "type": "TEXT",
     "name": "commonEventName",
     "displayName": "Freshpaint Event Name",
     "simpleValueType": true,
@@ -163,25 +205,6 @@ ___TEMPLATE_PARAMETERS___
         "type": "EQUALS"
       }
     ]
-  },
-  {
-    "type": "TEXT",
-    "name": "commonDestConfigNames",
-    "displayName": "Freshpaint Config Name(s) (optional)",
-    "help": "To deliver using a configuration other than the primary Freshpaint configuration, specify one or more configuration names, comma-delimited if two or more",
-    "simpleValueType": true,
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "fbPixelEvent",
-        "type": "EQUALS"
-      },
-      {
-        "paramName": "tagType",
-        "paramValue": "theTradeDeskEvent",
-        "type": "EQUALS"
-      }
-    ],
   },
   {
     "type": "TEXT",

--- a/template.tpl
+++ b/template.tpl
@@ -123,42 +123,14 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "TEXT",
-    "name": "ga4InstanceNames",
-    "displayName": "Specific Measurement ID(s) (optional)",
-    "help": "If multiple Measurement IDs are configured for the Google Analytics 4 (Proxy), specify one or more specific Measurement IDs to deliver to (otherwise, this event will be delivered to all configured Measurement IDs)",
-    "simpleValueType": true,
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "ga4Event",
-        "type": "EQUALS"
-      },
-    ],
-  },
-  {
-    "type": "TEXT",
     "name": "fbInstanceNames",
     "displayName": "Specific Pixel ID(s) (optional)",
-    "help": "If multiple Pixel IDs are configured for the Facebook Conversions API, specify one or more specific Pixel IDs to deliver to (otherwise, this event will be delivered to all configured Pixel IDs)",
+    "help": "If multiple Pixel IDs are configured for the Facebook Conversions API destination, specify one or more specific Pixel IDs to deliver to (if left blank, this event will be delivered to all configured Pixel IDs)",
     "simpleValueType": true,
     "enablingConditions": [
       {
         "paramName": "tagType",
         "paramValue": "fbPixelEvent",
-        "type": "EQUALS"
-      },
-    ],
-  },
-  {
-    "type": "TEXT",
-    "name": "theTradeDeskInstanceNames",
-    "displayName": "Specific Advertiser ID(s) (optional)",
-    "help": "If multiple Advertiser IDs are configured for theTradeDesk, specify one or more specific Advertiser IDs to deliver to (otherwise, this event will be delivered to all configured Advertiser IDs)",
-    "simpleValueType": true,
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "theTradeDeskEvent",
         "type": "EQUALS"
       },
     ],
@@ -205,6 +177,20 @@ ___TEMPLATE_PARAMETERS___
         "type": "EQUALS"
       }
     ]
+  },
+  {
+    "type": "TEXT",
+    "name": "commonDestConfigNames",
+    "displayName": "Freshpaint Config Name(s) (optional)",
+    "help": "To deliver using a configuration other than the primary Freshpaint configuration, specify one or more configuration names, comma-delimited if two or more",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "theTradeDeskEvent",
+        "type": "EQUALS"
+      }
+    ],
   },
   {
     "type": "TEXT",


### PR DESCRIPTION
# TL;DR
Multi-config for Facebook cAPI, using the generalized multi-config approach.

This gives more context on the gtm template versions we'll need to release: https://www.notion.so/freshpaintio/RFC-Multi-config-migration-approach-from-workarounds-to-generalized-solution-cd892bbcee1d499893103908f0f40219?pvs=4#3acbe68c68b04f0d9294251c4032b370

# Notes
* If only the old commonDestConfigNames param is present, it is still used to populate the dest_config_names prop