### PR TITLE
CA-40 Add GA4-proxy, Google Ads, theTradeDesk generalized multi-config support

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -33,24 +33,6 @@ ___TEMPLATE_PARAMETERS___
 
 [
   {
-    "type": "TEXT",
-    "name": "envID",
-    "displayName": "Freshpaint Environment ID",
-    "simpleValueType": true,
-    "valueValidators": [
-      {
-        "type": "NON_EMPTY"
-      }
-    ],
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "init",
-        "type": "EQUALS"
-      }
-    ]
-  },
-  {
     "type": "SELECT",
     "name": "tagType",
     "displayName": "Freshpaint Tag Type",
@@ -111,10 +93,6 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "track",
         "displayValue": "Track"
-      },
-      {
-        "value": "init",
-        "displayValue": "Init-OBSOLETE"
       },
     ],
     "notSetText": "-",
@@ -1948,15 +1926,6 @@ function parseParamTable(inputProps, overrides) {
 
 const processEvent = () => {
   let envID = undefined;
-  if (data.tagType === "init") {
-    if (!data.envID) {
-      log("[freshpaint-GTM] environment ID is required for init tag");
-      data.gtmOnFailure();
-      return;
-    }
-
-    envID = data.envID;
-  }
 
   // initialize environment
   // if already done before then this is a no-op
@@ -2519,7 +2488,7 @@ const addEventProperties = (props) => {
 
 const registerCallConversion = (tagIdConversionLabel, phoneNbr) => {
   callFreshpaintProxy("apply", {
-    envID: data.envID,
+    envID: undefined,
     methodName: "registerCallConversion",
     methodArgs: [tagIdConversionLabel, phoneNbr],
   });

--- a/template.tpl
+++ b/template.tpl
@@ -123,6 +123,34 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "TEXT",
+    "name": "googleAdsInstanceName",
+    "displayName": "Specific Configuration ID (optional)",
+    "help": "If multiple Conversion IDs are configured for the Google Ads destination, specify one to deliver to (if left blank, this event will be delivered to all configured Conversion IDs)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsEvent",
+        "type": "EQUALS"
+      },
+    ],
+  },
+  {
+    "type": "TEXT",
+    "name": "ga4InstanceNames",
+    "displayName": "Specific Measurement ID(s) (optional)",
+    "help": "If multiple Measurement IDs are configured for the Google Analytics 4 Proxy destination, specify one or more specific Measurement IDs to deliver to (if left blank, this event will be delivered to all configured Measurement IDs)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "ga4Event",
+        "type": "EQUALS"
+      },
+    ],
+  },
+  {
+    "type": "TEXT",
     "name": "fbInstanceNames",
     "displayName": "Specific Pixel ID(s) (optional)",
     "help": "If multiple Pixel IDs are configured for the Facebook Conversions API destination, specify one or more specific Pixel IDs to deliver to (if left blank, this event will be delivered to all configured Pixel IDs)",
@@ -243,20 +271,6 @@ ___TEMPLATE_PARAMETERS___
       {
         "paramName": "tagType",
         "paramValue": "googleAdsCallConversionsEvent",
-        "type": "EQUALS"
-      }
-    ]
-  },
-  {
-    "type": "TEXT",
-    "name": "googleAdsConversionId",
-    "displayName": "Conversion ID (optional)",
-    "help": "This is needed only if the Conversion ID differs from the one configured in the Freshpaint Destination",
-    "simpleValueType": true,
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "googleAdsEvent",
         "type": "EQUALS"
       }
     ]

--- a/template.tpl
+++ b/template.tpl
@@ -128,7 +128,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "TEXT",
     "name": "googleAdsInstanceName",
-    "displayName": "Specific Configuration ID (optional)",
+    "displayName": "Specific Conversion ID (optional)",
     "help": "If multiple Conversion IDs are configured for the Google Ads destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Conversion IDs)",
     "simpleValueType": true,
     "enablingConditions": [

--- a/template.tpl
+++ b/template.tpl
@@ -2455,6 +2455,7 @@ const identify = (userID, props, options) => {
     args = [userID].concat(args);
   }
   callFreshpaintProxy("apply", {
+    // envID is no longer used, left in for backward compatibility
     envID: undefined,
     methodName: "identify",
     methodArgs: args,

--- a/template.tpl
+++ b/template.tpl
@@ -2093,7 +2093,10 @@ const processGA4Event = () => {
   const ga4ProxySDKKey = "Google Analytics 4 Proxy";
   let options = generateOptions(ga4ProxySDKKey);
 
-  const instanceNamesToUse = data.fbInstanceNames.trim();
+  let instanceNamesToUse;
+  if (data.ga4InstanceNames) {
+    instanceNamesToUse = data.ga4InstanceNames.trim();
+  }
   if (instanceNamesToUse) {
     options = generateOptionsFromInstances(ga4ProxySDKKey, instanceNamesToUse, true);
   }
@@ -2141,7 +2144,10 @@ const processFBPixelEvent = () => {
       data.fbObjectPropertiesFromVariable : {};
   const mergedObjectProps = mergeObj(objectPropsFromVar, objectProps);
 
-  const instanceNamesToUse = data.fbInstanceNames.trim();
+  let instanceNamesToUse;
+  if (data.fbInstanceNames) {
+    instanceNamesToUse = data.fbInstanceNames.trim();
+  }
   if (instanceNamesToUse) {
     options = generateOptionsFromInstances(facebookCAPISDKKey, instanceNamesToUse, true);
   } else if (data.commonDestConfigNames) {
@@ -2295,11 +2301,14 @@ const processGoogleAdsEvent = () => {
 
     props.conversion_label = data.googleAdsConversionLabel;
 
-    const instanceNameToUse = data.googleAdsInstanceName.trim();
+    let instanceNameToUse;
+    if (data.googleAdsInstanceName) {
+      instanceNameToUse = data.googleAdsInstanceName.trim();
+    }
     if (instanceNameToUse) {
       options = generateOptionsFromInstances(googleAdsSDKKey, instanceNameToUse, false);
       if (options === undefined) {
-        log("ERROR: Multiple Google Ads Conversion IDs not supported");
+        log("ERROR: Multiple Google Ads Conversion IDs not supported: " + instanceNameToUse);
         data.gtmOnFailure();
         return;
       }
@@ -2337,18 +2346,21 @@ const processGoogleAdsCallConversionsEvent = () => {
 
 const processTheTradeDeskEvent = () => {
   const theTradeDeskSDKKey = "theTradeDesk";
-  const options = generateOptions(theTradeDeskSDKKey);
+  let options = generateOptions(theTradeDeskSDKKey);
 
   // make track call
 
   if (data.commonEventName && data.theTradeDeskTrackerOrUPixelIDValue) {
     const props = parseParamTable(data.theTradeDeskTDEventParameters || []);
 
-    const instanceNameToUse = data.theTradeDeskInstanceName.trim();
+    let instanceNameToUse;
+    if (data.theTradeDeskInstanceName) {
+      instanceNameToUse = data.theTradeDeskInstanceName.trim();
+    }
     if (instanceNameToUse) {
       options = generateOptionsFromInstances(theTradeDeskSDKKey, instanceNameToUse, false);
       if (options === undefined) {
-        log("ERROR: Multiple theTradeDesk Advertiser IDs not supported");
+        log("ERROR: Multiple theTradeDesk Advertiser IDs not supported: " + instanceNameToUse);
         data.gtmOnFailure();
         return;
       }
@@ -2644,5 +2656,6 @@ scenarios: []
 ___NOTES___
 
 Created on 29/03/2023, 15:36:11
+
 
 


### PR DESCRIPTION
## For details see: 
* https://linear.app/freshpaint/issue/CA-40/gtm-template-updated-for-multi-config-for-ga4-proxy-google-ads
* [RFC: Multi-config migration approach from workarounds to generalized solution](https://www.notion.so/freshpaintio/RFC-Multi-config-migration-approach-from-workarounds-to-generalized-solution-cd892bbcee1d499893103908f0f40219#c815385661854cbdbdc3dfc5a7deebe8)

## Other change(s)
* Removed 'init-OBSOLETE' tag from subtype dropdown
   * Retested on fptest-buc+test - an existing 'init' tags continue to be a nop (no error) 

## Testing notes
* Tested all permutations (no override, single override, multi-override) for the affected destination types, on GTM container fptest-buc+test