### PR TITLE
CA-63 Add LinkedIn Ads template support

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -81,6 +81,10 @@ ___TEMPLATE_PARAMETERS___
         "displayValue": "Basis"
       },
       {
+        "value": "linkedInAdsEvent",
+        "displayValue": "LinkedIn Ads"
+      },
+      {
         "value": "bingAdsEvent",
         "displayValue": "Bing Ads"
       },
@@ -184,6 +188,11 @@ ___TEMPLATE_PARAMETERS___
         "paramName": "tagType",
         "paramValue": "basisEvent",
         "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "linkedInAdsEvent",
+        "type": "EQUALS"
       }
     ]
   },
@@ -212,6 +221,25 @@ ___TEMPLATE_PARAMETERS___
         "paramValue": "identify",
         "type": "EQUALS"
       }
+    ]
+  },
+  {
+    "type": "TEXT",
+    "name": "linkedInAdsConversionIds",
+    "displayName": "Conversion ID(s) (max. 3)",
+    "help": "Enter 1-3 conversion ids separated by a comma.",
+    "simpleValueType": true,
+    "valueValidators": [
+      {
+        "type": "NON_EMPTY"
+      }
+    ],
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "linkedInAdsEvent",
+        "type": "EQUALS"
+      },
     ]
   },
   {
@@ -2005,6 +2033,8 @@ const processEvent = () => {
     processGA4Event();
   } else if (data.tagType === "fbPixelEvent") {
     processFBPixelEvent();
+  } else if (data.tagType === "linkedInAdsEvent") {
+    processLinkedInAdsEvent();
   } else if (data.tagType === "twitterAdsEvent") {
     processTwitterEvent();
   } else if (data.tagType === "bingAdsEvent") {
@@ -2346,6 +2376,33 @@ const processGoogleAdsCallConversionsEvent = () => {
   data.gtmOnSuccess();
 };
 
+const processLinkedInAdsEvent = () => {
+  const options = generateOptions("linkedin-ads");
+
+  const conversionIdsToUse = data.linkedInAdsConversionIds.trim();
+  const conversionIds = conversionIdsToUse.split(',');
+
+  if (conversionIds.length === 0) {
+    log("ERROR: Freshpaint LinkedIn Ads GTM Template missing Conversion ID(s): " + data.commonEventName);
+    data.gtmOnFailure();
+    return;
+  } else if (conversionIds.length > 3) {
+    log("ERROR: Freshpaint LinkedIn Ads GTM Template supports only up to 3 Conversion IDs: " + data.commonEventName);
+    data.gtmOnFailure();
+    return;
+  }
+
+  // make track call(s) for each conversionId
+  conversionIds.forEach(id => {
+    const props = {};
+    props.conversion_id = id.trim();
+
+    track(data.commonEventName, props, options);
+  });
+
+  data.gtmOnSuccess();
+};
+
 const processTheTradeDeskEvent = () => {
   const options = generateOptions("theTradeDesk");
 
@@ -2395,7 +2452,7 @@ const processTheTradeDeskEvent = () => {
 
     data.gtmOnSuccess();
   } else {
-    log("ERROR: Freshpaint theTradeDesk GTM Template missing eventNme and / or trackerOrUPixelIDValue");
+    log("ERROR: Freshpaint theTradeDesk GTM Template missing eventName and / or trackerOrUPixelIDValue");
     data.gtmOnFailure();
   }
 };


### PR DESCRIPTION
# TL;DR

Freshpaint GTM Template support for the LinkedIn Ads destination.

# Summary
* Accepts up to 3 Conversion IDs, as do the two community gallery templates (one published by LinkedIn).
* The implementation here is to send up to 3 track calls, one for each Conversion ID - the same as the aforementioned gallery templates do (in their case, they're doing a LinkedIn tag call instead of track)
* This is a different use case than multi-config, where the config param differs (e.g., Facebook Pixel ID, GA4 Measurement ID) - for those, we use multiple dest instances, and specify those in the integrations object.

# Screenshot
![image](https://github.com/freshpaint-io/freshpaint-gtm-template/assets/7854875/bd4ea6a1-cab3-49a8-a757-732f998a1272)
