### PR TITLE
Bug: Only show enhanced conversion group for floodlight

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -685,6 +685,13 @@ ___TEMPLATE_PARAMETERS___
     "name": "floodlightEnhancedConversionsGroup",
     "displayName": "Enhanced Conversions",
     "groupStyle": "ZIPPY_CLOSED",
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "type": "EQUALS",
+        "paramValue": "floodlightEvent"
+      }
+    ],
     "subParams": [
       {
         "type": "CHECKBOX",


### PR DESCRIPTION
Fixes a regression from #35 where the Floodlight enhanced conversions field group showed up regardless of selected tag type. This group should only be displayed for Floodlight

Before:
<img width="821" alt="Screenshot 2024-04-08 at 16 40 57" src="https://github.com/freshpaint-io/freshpaint-gtm-template/assets/7072770/4c278a49-bd3e-49c3-91e8-53c6e9631b3c">


After:
<img width="821" alt="Screenshot 2024-04-08 at 16 39 31" src="https://github.com/freshpaint-io/freshpaint-gtm-template/assets/7072770/4a988318-88d1-4bc4-ad95-c1b135d85f15">


Still works with floodlight
<img width="821" alt="Screenshot 2024-04-08 at 16 39 38" src="https://github.com/freshpaint-io/freshpaint-gtm-template/assets/7072770/8d937ed2-401e-43bb-a744-082695f2f6b7">
