### PR TITLE
FP-2685 FP-2687 Add Reddit Ads, Pinterest Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ As described in the [Freshpaint documentation](https://documentation.freshpaint.
   * Google Analytics 4 (proxy)
   * Google Ads
   * Google Ads Call Conversion
+  * Google Campaign Manager 360 API
   * Facebook Conversions API
-  * Floodlight
   * Basis
-  * LinkedIn Ads
-  * Bing Ads
-  * Impact.com
-  * Stackadapt
   * theTradeDesk
+  * Stackadapt
+  * Bing Ads
+  * TikTok Ads
+  * Impact.com
+  * LinkedIn Ads
+  * Reddit Ads
+  * Pinterest Ads
   * Twitter Ads
 * track
 * identify


### PR DESCRIPTION
# TL;DR 
see linear tix for scope

# Other notes
* Did both pinterest and reddit in one PR to quicken the gallery update cycle

# Testing notes
* Tested on gtm container: fp-test-buc+test
- [x] track with reddit ads opt-in
- [x] track with pinterest ads opt-in
- [x] reddit ads subtype with optional email arg
- [x] reddit ads subtype with optional specific account id arg
- [x] pinterest ads subtype with optional email arg
