### PR TITLE
FP-2761: viant support

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -318,7 +318,6 @@ ___TEMPLATE_PARAMETERS___
         "paramName": "tagType",
         "paramValue": "redditAdsEvent",
         "type": "EQUALS"
-      }
       },
       {
         "paramName": "tagType",

--- a/template.tpl
+++ b/template.tpl
@@ -2936,7 +2936,7 @@ const processGoogleCM360Event = () => {
   data.gtmOnSuccess();
 };
 
-const processViantEvent = () = {
+const processViantEvent = () => {
   const viantSDKKey = "viant";
 
   if (!data.commonEventName) {


### PR DESCRIPTION
GoHealth is going to be beta testing Viant for us, and they use Google Tag Manager.

This PR adds support for Viant tags.

I loaded this template and tried out a couple of events. Both all instance and specific instance tag triggers worked for me, so we should be good with this change.

<img width="1755" alt="Screenshot 2024-11-21 at 7 41 00 PM" src="https://github.com/user-attachments/assets/7d1f43e1-0051-4022-931e-12f6289a2c17">
<img width="1755" alt="Screenshot 2024-11-21 at 7 41 16 PM" src="https://github.com/user-attachments/assets/6b886d8c-e326-44ba-bf9a-776e60bb02c0">
<img width="1755" alt="Screenshot 2024-11-21 at 7 41 24 PM" src="https://github.com/user-attachments/assets/588da5a7-d1a1-4c20-af05-4dfb03e7ce4e">
