### PR TITLE
FP-3045: Fix identify. Options must always be passed third.

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -3067,15 +3067,11 @@ const callFreshpaintProxy = (cmdName, args) => {
 };
 
 const identify = (userID, props, options) => {
-  let args = [props, options];
-  if (userID) {
-    args = [userID].concat(args);
-  }
   callFreshpaintProxy("apply", {
     // envID is no longer used, left in for backward compatibility
     envID: undefined,
     methodName: "identify",
-    methodArgs: args,
+    methodArgs: [userID, props, options],
   });
 };
 


### PR DESCRIPTION
I was able to test this by importing the template file into GTM and verified that the options argument is now passed to identify correctly