### PR TITLE
Use most recent MERGE commit SHA1 TAN-152

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://freshpaint.io"
 documentation: "https://documentation.freshpaint.io/integrations/google-tag-manager-integration"
 versions:
-  - sha: 82fb4dfd6a47e69991885d0e669385a1f760f0af
+  - sha: e19dc45cb7290e977b3517b834db32da182e34cb
     changeNotes: Add multi-config support for Pinterest Ads


### PR DESCRIPTION
This PR corrects the git commit SHA we use to reference the right version of the codebase for releasing GTM to the GTM gallery.