### PR TITLE
Default to standard counting method for CM360 floodlight counter if not specified

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -3165,9 +3165,7 @@ const processGoogleCM360Event = () => {
     return;
   }
   if (!data.googleCM360FloodlightCountingMethod) {
-    log("ERROR: Freshpaint CM360 Floodlight Counter GTM Template missing Counting Method");
-    data.gtmOnFailure();
-    return;
+    data.googleCM360FloodlightCountingMethod = "standard";
   }
 
   let options = generateOptions(googleCM360SDKKey);


### PR DESCRIPTION
See ticket for container export.

Tested with impacted customer. 'Standard' counting is a safe default for customers migrated before other counting methods were supported.