### PR TITLE
IND-1524 add ga4 shared ev prop, LinkedIn cAPI props

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -59,20 +59,12 @@ ___TEMPLATE_PARAMETERS___
         "displayValue": "Facebook Conversions API"
       },
       {
-        "value": "floodlightEvent",
-        "displayValue": "Floodlight - DEPRECATED - instead use Google Campaign Manager 360 Conversions API"
-      },
-      {
         "value": "basisEvent",
         "displayValue": "Basis"
       },
       {
         "value": "viantEvent",
         "displayValue": "Viant"
-      },
-      {
-        "value": "linkedInAdsEvent",
-        "displayValue": "LinkedIn Ads"
       },
       {
         "value": "linkedInAdsCAPIEvent",
@@ -125,6 +117,14 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "track",
         "displayValue": "Track"
+      },
+      {
+        "value": "linkedInAdsEvent",
+        "displayValue": "LinkedIn Ads- DEPRECATED - instead use LinkedIn Ads Conversions API"
+      },
+      {
+        "value": "floodlightEvent",
+        "displayValue": "Floodlight - DEPRECATED - instead use Google Campaign Manager 360 Conversions API"
       },
     ],
     "notSetText": "-",
@@ -1989,6 +1989,11 @@ ___TEMPLATE_PARAMETERS___
         "paramValue": "mntnEvent",
         "type": "EQUALS"
       },
+      {
+        "paramName": "tagType",
+        "paramValue": "linkedInAdsCAPIEvent",
+        "type": "EQUALS"
+      }
     ]
   },
   {
@@ -2191,16 +2196,8 @@ ___TEMPLATE_PARAMETERS___
               "displayValue": "Bing Ads"
             },
             {
-              "value": "Floodlight",
-              "displayValue": "Floodlight - DEPRECATED - instead use Google Campaign Manager 360 Conversions API"
-            },
-            {
               "value": "impactdotcom",
               "displayValue": "impact.com"
-            },
-            {
-              "value": "linkedin-ads",
-              "displayValue": "LinkedIn Ads"
             },
             {
               "value": "LinkedIn Ads Conversions API",
@@ -2245,6 +2242,14 @@ ___TEMPLATE_PARAMETERS___
             {
               "value": "Webhooks",
               "displayValue": "Webhooks"
+            },
+            {
+              "value": "linkedin-ads",
+              "displayValue": "LinkedIn Ads - DEPRECATED - instead use LinkedIn Ads Conversions API"
+            },
+            {
+              "value": "Floodlight",
+              "displayValue": "Floodlight - DEPRECATED - instead use Google Campaign Manager 360 Conversions API"
             }
           ],
           "simpleValueType": true
@@ -3088,7 +3093,7 @@ const processLinkedInAdsCAPIEvent = () => {
 
   // make track call(s) for each conversionId
   conversionIds.forEach(id => {
-    const props = {};
+    const props = parseSimpleTable(data.commonEventProperties || []);
     props.conversion_id = id.trim();
 
     track(data.commonEventName, props, options);

--- a/template.tpl
+++ b/template.tpl
@@ -2420,7 +2420,7 @@ function getEventPropsFromGoogEventSettingsVar(inputProps) {
     }
 
     eventProps[key] = inputProps[key];
-}
+  }
 
   return eventProps;
 }

--- a/template.tpl
+++ b/template.tpl
@@ -1927,6 +1927,20 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
+    "type": "TEXT",
+    "name": "ga4EventPropsVariable",
+    "displayName": "Event Properties Variable",
+    "help": "If specified, must be a variable returning an object, such as a Google Tag: Event Settings or Custom JavaScript variable, in {{varname}} format",
+    "simpleValueType": true,
+    "enablingConditions":  [
+      {
+        "paramName": "tagType",
+        "paramValue": "ga4Event",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
     "type": "SIMPLE_TABLE",
     "name": "commonEventProperties",
     "displayName": "Event Properties",
@@ -2613,9 +2627,14 @@ const processGA4Event = () => {
     identify(undefined, props, options);
   }
 
+  const eventPopsFromVar =
+    getType(data.ga4EventPropsVariable) === "object" ?
+      data.ga4EventPropsVariable : {};
+
   if (data.commonEventName) {
     const props = parseSimpleTable(data.commonEventProperties || []);
-    track(data.commonEventName, props, options);
+
+    track(data.commonEventName, mergeObj(eventPopsFromVar, props), options);
 
       data.gtmOnSuccess();
   } else {

--- a/template.tpl
+++ b/template.tpl
@@ -120,7 +120,7 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "value": "linkedInAdsEvent",
-        "displayValue": "LinkedIn Ads- DEPRECATED - instead use LinkedIn Ads Conversions API"
+        "displayValue": "LinkedIn Ads"
       },
       {
         "value": "floodlightEvent",
@@ -2245,7 +2245,7 @@ ___TEMPLATE_PARAMETERS___
             },
             {
               "value": "linkedin-ads",
-              "displayValue": "LinkedIn Ads - DEPRECATED - instead use LinkedIn Ads Conversions API"
+              "displayValue": "LinkedIn Ads"
             },
             {
               "value": "Floodlight",


### PR DESCRIPTION
# TL;DR
Two primary changes:
1. GA4-proxy now supports an optional Event Properties Variable. This allows usage of the Google Tag Shared Event Properties Variable on FP GA4 event tags. Before, the GTM Migration would propagate all props from the Google Tag Shared Event Properties Variable to each FP GA4 event tag referencing it,  resulting in duplicated data in GTM and making the migration harder to review / validate.

<img width="741" height="495" alt="image" src="https://github.com/user-attachments/assets/3a45b7e5-e7ad-4155-b305-ba7ad9ce1ee5" />

2. LinkedIn Ads Conversion API now supports free form properties entry. Since the LinkedIn Ads cAPI now supports various properties like email, unlike the LinkedIn Ads destination, these need to be supported via GTM.

<img width="596" height="477" alt="image" src="https://github.com/user-attachments/assets/71e0986c-43a2-4c6b-9093-f2e6264b6d03" />

# Other changes
* Moved LinkedIn Ads to the bottom of the UI-picker lists for subtype and track opt-in. 

# Testing notes
* In each case, verified proper events sent to Live View
## GA4-proxy Event Properties Variable
- [x] Tested 3 variations on fptest-buc:
  - [x] GA4 event tag with props, no shared props var
  - [x]  GA4 event tag with props, Google Tag Shared Event Properties Variable 
  - [x] GA4 event tag with props, Custom JavaScript variable
## LinkedIn Ads cAPI properties
  - [x] LinkedIn Ads cAPI tag with no props
  - [x] LinkedIn Ads cAPI tag with props


