### PR TITLE
IND-1462 Fix twitter template for event_name

### DIFF
--- a/src/generatedParameters.json
+++ b/src/generatedParameters.json
@@ -365,6 +365,11 @@
       },
       {
         "paramName": "tagType",
+        "paramValue": "twitterAdsEvent",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
         "paramValue": "viantEvent",
         "type": "EQUALS"
       }
@@ -1849,25 +1854,6 @@
       {
         "paramName": "tagType",
         "paramValue": "tikTokAdsEvent",
-        "type": "EQUALS"
-      }
-    ]
-  },
-  {
-    "type": "TEXT",
-    "name": "twitterEventId",
-    "displayName": "Event ID",
-    "help": "Enter the name of the TikTok Event ID. This will be the Freshpaint Event Name as well.",
-    "simpleValueType": true,
-    "valueValidators": [
-      {
-        "type": "NON_EMPTY"
-      }
-    ],
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "twitterAdsEvent",
         "type": "EQUALS"
       }
     ]

--- a/src/parameters/integrations/twitter.ts
+++ b/src/parameters/integrations/twitter.ts
@@ -1,5 +1,6 @@
 import {tagTypeEq, paramTable, radio, select, text, nonEmpty} from '../helpers';
 import { twitterAdsEvent } from '../integration';
+import {commonEventName} from "../common";
 
 export default function TwitterParams() {
   const isTwitterEvent = tagTypeEq(twitterAdsEvent);
@@ -60,14 +61,7 @@ export default function TwitterParams() {
   });
 
   return [
-    text({
-      name: 'twitterEventId',
-      displayName: 'Event ID',
-      help: 'Enter the name of the TikTok Event ID. This will be the Freshpaint Event Name as well.',
-      simpleValueType: true,
-      enablingConditions: onlyForTwitter,
-      valueValidators: [nonEmpty()],
-    }),
+    commonEventName(onlyForTwitter),
     paramTable({
       name: 'twitterEventParameters',
       displayName: 'Event Parameters',

--- a/src/web.js
+++ b/src/web.js
@@ -472,7 +472,7 @@ const processTikTokAdsEvent = () => {
 const processTwitterEvent = () => {
   const options = generateOptions("Twitter Ads");
 
-  const eventName = data.twitterEventId;
+  const eventName = data.commonEventName;
   const props = parseParamTable(data.twitterEventParameters || []);
 
   track(eventName, props, options);

--- a/template.tpl
+++ b/template.tpl
@@ -394,6 +394,11 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "paramName": "tagType",
+        "paramValue": "twitterAdsEvent",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
         "paramValue": "viantEvent",
         "type": "EQUALS"
       }
@@ -1883,25 +1888,6 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
-    "type": "TEXT",
-    "name": "twitterEventId",
-    "displayName": "Event ID",
-    "help": "Enter the name of the TikTok Event ID. This will be the Freshpaint Event Name as well.",
-    "simpleValueType": true,
-    "valueValidators": [
-      {
-        "type": "NON_EMPTY"
-      }
-    ],
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "twitterAdsEvent",
-        "type": "EQUALS"
-      }
-    ]
-  },
-  {
     "type": "PARAM_TABLE",
     "name": "twitterEventParameters",
     "displayName": "Event Parameters",
@@ -2782,7 +2768,7 @@ const processTikTokAdsEvent = () => {
 const processTwitterEvent = () => {
   const options = generateOptions("Twitter Ads");
 
-  const eventName = data.twitterEventId;
+  const eventName = data.commonEventName;
   const props = parseParamTable(data.twitterEventParameters || []);
 
   track(eventName, props, options);


### PR DESCRIPTION
# TL;DR

See linked linear ticket

# Testing notes
* fp-twitter-ads-migration container
* file-based template
* test tag with value prop, event value
* url used, including a click ID: http://localhost:9010/gtm-legacy-fptest-buc-snippet-app.html?twclid=abc
- [x] Observed event verification success, including sending of value prop

# Screenshot preview
This will be put in docs when it's available in gallery: 
<img width="931" height="589" alt="image" src="https://github.com/user-attachments/assets/651dddcc-eecf-451e-8b3e-721d3b3a5224" />

