### PR TITLE
LinkedIn CAPI instance id support

### DIFF
--- a/src/generatedParameters.json
+++ b/src/generatedParameters.json
@@ -204,6 +204,20 @@
   },
   {
     "type": "TEXT",
+    "name": "linkedInAdsCAPIInstanceName",
+    "displayName": "Specific Instance ID (optional)",
+    "help": "If multiple instances are configured for the LinkedIn CAPI integration type, specify one to deliver to (if left blank, this event will be delivered to all configured integrations)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "linkedInAdsCAPIEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
     "name": "mntnInstanceName",
     "displayName": "Specific Advertiser ID (optional)",
     "help": "If multiple Advertiser IDs are configured for the MNTN destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Advertiser IDs)",

--- a/src/parameters/integrations/linkedinCAPI.ts
+++ b/src/parameters/integrations/linkedinCAPI.ts
@@ -9,6 +9,13 @@ export default function LinkedInCAPIParams() {
   return [
     commonEventName(onlyForLinkedInCAPI),
     text({
+      name: 'linkedInAdsCAPIInstanceName',
+      displayName: 'Specific Instance ID (optional)',
+      help: 'If multiple instances are configured for the LinkedIn CAPI integration type, specify one to deliver to (if left blank, this event will be delivered to all configured integrations)',
+      simpleValueType: true,
+      enablingConditions: onlyForLinkedInCAPI,
+    }),
+    text({
       name: 'linkedInAdsCAPIConversionIds',
       displayName: 'Conversion ID(s) (max. 3)',
       help: 'Enter 1-3 conversion ids separated by a comma.',

--- a/src/web.js
+++ b/src/web.js
@@ -746,7 +746,17 @@ const processLinkedInAdsEvent = () => {
 
 const processLinkedInAdsCAPIEvent = () => {
   const linkedInCAPISDKKey = "LinkedIn Ads Conversions API";
-  const options = generateOptions(linkedInCAPISDKKey);
+  let options = generateOptions(linkedInCAPISDKKey);
+
+  if (data.linkedInAdsCAPIInstanceName) {
+    const instanceNameToUse = data.linkedInAdsCAPIInstanceName.trim();
+    options = generateOptionsFromInstances(linkedInCAPISDKKey, instanceNameToUse, false);
+    if (options === undefined) {
+      log("ERROR: Multiple LinkedIn Ads CAPI instance IDs not supported: " + instanceNameToUse);
+      data.gtmOnFailure();
+      return;
+    }
+  }
 
   const conversionIdsToUse = data.linkedInAdsCAPIConversionIds.trim();
   const conversionIds = conversionIdsToUse.split(',');

--- a/template.tpl
+++ b/template.tpl
@@ -233,6 +233,20 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "TEXT",
+    "name": "linkedInAdsCAPIInstanceName",
+    "displayName": "Specific Instance ID (optional)",
+    "help": "If multiple instances are configured for the LinkedIn CAPI integration type, specify one to deliver to (if left blank, this event will be delivered to all configured integrations)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "linkedInAdsCAPIEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
     "name": "mntnInstanceName",
     "displayName": "Specific Advertiser ID (optional)",
     "help": "If multiple Advertiser IDs are configured for the MNTN destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Advertiser IDs)",
@@ -3042,7 +3056,17 @@ const processLinkedInAdsEvent = () => {
 
 const processLinkedInAdsCAPIEvent = () => {
   const linkedInCAPISDKKey = "LinkedIn Ads Conversions API";
-  const options = generateOptions(linkedInCAPISDKKey);
+  let options = generateOptions(linkedInCAPISDKKey);
+
+  if (data.linkedInAdsCAPIInstanceName) {
+    const instanceNameToUse = data.linkedInAdsCAPIInstanceName.trim();
+    options = generateOptionsFromInstances(linkedInCAPISDKKey, instanceNameToUse, false);
+    if (options === undefined) {
+      log("ERROR: Multiple LinkedIn Ads CAPI instance IDs not supported: " + instanceNameToUse);
+      data.gtmOnFailure();
+      return;
+    }
+  }
 
   const conversionIdsToUse = data.linkedInAdsCAPIConversionIds.trim();
   const conversionIds = conversionIdsToUse.split(',');


### PR DESCRIPTION
## Context
We're supporting Multiconfig for LinkedIn CAPI. This allows the user to specify instance names. 

Tagging @tiffanyhan just because this is my first time contributing since the repo restructure and I want to make sure I didn't miss anything! 

## Testing Notes
- instance ID on integrations object when provided
- integrations object left generic when instance ID not provided