### PR TITLE
SiriusXM GTM

### DIFF
--- a/src/generatedParameters.json
+++ b/src/generatedParameters.json
@@ -1787,8 +1787,8 @@
   {
     "type": "TEXT",
     "name": "siriusXMAppName",
-    "displayName": "Specific Application ID (optional)",
-    "help": "If multiple Application IDs are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application IDs)",
+    "displayName": "Specific Application Name (optional)",
+    "help": "If multiple Application Names are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application Names)",
     "simpleValueType": true,
     "enablingConditions": [
       {

--- a/src/generatedParameters.json
+++ b/src/generatedParameters.json
@@ -77,6 +77,10 @@
         "displayValue": "Reddit Ads"
       },
       {
+        "value": "siriusXMEvent",
+        "displayValue": "SiriusXM"
+      },
+      {
         "value": "twitterAdsEvent",
         "displayValue": "Twitter Ads"
       },
@@ -351,6 +355,11 @@
       {
         "paramName": "tagType",
         "paramValue": "redditAdsEvent",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
         "type": "EQUALS"
       },
       {
@@ -1763,6 +1772,20 @@
   },
   {
     "type": "TEXT",
+    "name": "siriusXMAppName",
+    "displayName": "Specific Application ID (optional)",
+    "help": "If multiple Application IDs are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application IDs)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
     "name": "stackAdaptConversionEventID",
     "displayName": "StackAdapt Conversion Event Unique ID",
     "simpleValueType": true,
@@ -1989,6 +2012,11 @@
       },
       {
         "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
         "paramValue": "stackAdaptEvent",
         "type": "EQUALS"
       },
@@ -2165,6 +2193,10 @@
             {
               "value": "pinterest-ads",
               "displayValue": "Pinterest Ads"
+            },
+            {
+              "value": "SiriusXM",
+              "displayValue": "SiriusXM"
             },
             {
               "value": "Twitter Ads",

--- a/src/generatedParameters.json
+++ b/src/generatedParameters.json
@@ -391,6 +391,11 @@
       },
       {
         "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
         "paramValue": "snapchatEvent",
         "type": "EQUALS"
       },
@@ -437,7 +442,9 @@
     "valueValidators": [
       {
         "type": "TABLE_ROW_COUNT",
-        "args": [1]
+        "args": [
+          1
+        ]
       }
     ],
     "enablingConditions": [
@@ -1801,6 +1808,20 @@
     ]
   },
   {
+    "type": "TEXT",
+    "name": "siriusXMAppName",
+    "displayName": "Specific Application Name (optional)",
+    "help": "If multiple Application Names are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application Names)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
     "type": "SELECT",
     "name": "snapchatEventName",
     "displayName": "Snapchat Event Name",
@@ -1938,20 +1959,6 @@
       {
         "value": "CUSTOM_EVENT_5",
         "displayValue": "Custom Event 5"
-      }
-    ]
-  },
-  {
-    "type": "TEXT",
-    "name": "siriusXMAppName",
-    "displayName": "Specific Application Name (optional)",
-    "help": "If multiple Application Names are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application Names)",
-    "simpleValueType": true,
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "siriusXMEvent",
-        "type": "EQUALS"
       }
     ]
   },
@@ -2179,6 +2186,11 @@
       {
         "paramName": "tagType",
         "paramValue": "pinterestAdsEvent",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
         "type": "EQUALS"
       },
       {

--- a/src/parameters/integration.ts
+++ b/src/parameters/integration.ts
@@ -14,6 +14,7 @@ export const theTradeDeskEvent = 'theTradeDeskEvent';
 export const tikTokAdsEvent = 'tikTokAdsEvent';
 export const pinterestAdsEvent = 'pinterestAdsEvent';
 export const redditAdsEvent = 'redditAdsEvent';
+export const siriusXMEvent = 'siriusXMEvent';
 export const twitterAdsEvent = 'twitterAdsEvent';
 export const addEventProperties = 'addEventProperties';
 export const identify = 'identify';
@@ -38,6 +39,7 @@ export const rootParamSelectItems = [
   { value: tikTokAdsEvent, displayValue: 'TikTok Ads' },
   { value: pinterestAdsEvent, displayValue: 'Pinterest Ads' },
   { value: redditAdsEvent, displayValue: 'Reddit Ads' },
+  { value: siriusXMEvent, displayValue: 'SiriusXM' },
   { value: twitterAdsEvent, displayValue: 'Twitter Ads' },
   { value: addEventProperties, displayValue: 'AddEventProperties' },
   { value: identify, displayValue: 'Identify' },
@@ -72,6 +74,7 @@ export const trackDestinationSelectItems = [
   { value: 'TikTok Ads', displayValue: 'TikTok Ads' },
   { value: 'reddit-ads', displayValue: 'Reddit Ads' },
   { value: 'pinterest-ads', displayValue: 'Pinterest Ads' },
+  { value: 'SiriusXM', displayValue: 'SiriusXM' },
   { value: 'Twitter Ads', displayValue: 'Twitter Ads' },
   { value: 'viant', displayValue: 'Viant' },
   { value: 'Webhooks', displayValue: 'Webhooks' },

--- a/src/parameters/integrations/siriusxm.ts
+++ b/src/parameters/integrations/siriusxm.ts
@@ -9,8 +9,8 @@ export default function MntnParams() {
   return [
     text({
       name: 'siriusXMAppName',
-      displayName: 'Specific Application ID (optional)',
-      help: 'If multiple Application IDs are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application IDs)',
+      displayName: 'Specific Application Name (optional)',
+      help: 'If multiple Application Names are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application Names)',
       simpleValueType: true,
       enablingConditions: onlyForSiriusXM,
     }),

--- a/src/parameters/integrations/siriusxm.ts
+++ b/src/parameters/integrations/siriusxm.ts
@@ -1,0 +1,20 @@
+import { commonEventName, commonEventProperties } from '../common';
+import { tagTypeEq, text } from '../helpers';
+import { siriusXMEvent } from '../integration';
+
+export default function MntnParams() {
+  const isSiriusXMEvent = tagTypeEq(siriusXMEvent);
+  const onlyForSiriusXM = [isSiriusXMEvent];
+
+  return [
+    text({
+      name: 'siriusXMAppName',
+      displayName: 'Specific Application ID (optional)',
+      help: 'If multiple Application IDs are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application IDs)',
+      simpleValueType: true,
+      enablingConditions: onlyForSiriusXM,
+    }),
+    commonEventName(onlyForSiriusXM),
+    commonEventProperties(onlyForSiriusXM),
+  ];
+}

--- a/src/parameters/integrations/siriusxm.ts
+++ b/src/parameters/integrations/siriusxm.ts
@@ -2,7 +2,7 @@ import { commonEventName, commonEventProperties } from '../common';
 import { tagTypeEq, text } from '../helpers';
 import { siriusXMEvent } from '../integration';
 
-export default function MntnParams() {
+export default function SiriusXMParams() {
   const isSiriusXMEvent = tagTypeEq(siriusXMEvent);
   const onlyForSiriusXM = [isSiriusXMEvent];
 

--- a/src/web.js
+++ b/src/web.js
@@ -182,6 +182,9 @@ const processEvent = () => {
     case "stackAdaptEvent":
       processStackAdaptEvent();
       break;
+    case "siriusXMEvent":
+      processSiriusXMEvent();
+      break;
     case "pinterestAdsEvent":
       processPinterestAdsEvent();
       break;
@@ -886,6 +889,19 @@ const processStackAdaptEvent = () => {
     data.gtmOnFailure();
   }
 };
+
+const processSiriusXMEvent = () => {
+  const options = generateOptions("SiriusXM");
+
+  if (data.siriusXMAppName) {
+    const appNameToUse = data.siriusXMAppName.trim();
+    options = generateOptionsFromInstances("SiriusXM", appNameToUse, false);
+    if (options === undefined) {
+      log("ERROR: Multiple SiriusXM App Names not supported: " + appNameToUse);
+      data.gtmOnFailure();
+      return;
+    }
+  }
 
 const processPinterestAdsEvent = () => {
   const pinterestSDKKey = "pinterest-ads";

--- a/src/web.js
+++ b/src/web.js
@@ -891,17 +891,19 @@ const processStackAdaptEvent = () => {
 };
 
 const processSiriusXMEvent = () => {
-  const options = generateOptions("SiriusXM");
+  const siriusXMSDKKey = "SiriusXM";
+  let options = generateOptions(siriusXMSDKKey);
 
   if (data.siriusXMAppName) {
     const appNameToUse = data.siriusXMAppName.trim();
-    options = generateOptionsFromInstances("SiriusXM", appNameToUse, false);
+    options = generateOptionsFromInstances(siriusXMSDKKey, appNameToUse, false);
     if (options === undefined) {
       log("ERROR: Multiple SiriusXM App Names not supported: " + appNameToUse);
       data.gtmOnFailure();
       return;
     }
   }
+};
 
 const processPinterestAdsEvent = () => {
   const pinterestSDKKey = "pinterest-ads";

--- a/src/web.js
+++ b/src/web.js
@@ -894,6 +894,12 @@ const processSiriusXMEvent = () => {
   const siriusXMSDKKey = "SiriusXM";
   let options = generateOptions(siriusXMSDKKey);
 
+  if (!data.commonEventName) {
+    log("ERROR: Freshpaint SiriusXM GTM Template missing eventName");
+    data.gtmOnFailure();
+    return;
+  }
+
   if (data.siriusXMAppName) {
     const appNameToUse = data.siriusXMAppName.trim();
     options = generateOptionsFromInstances(siriusXMSDKKey, appNameToUse, false);
@@ -903,6 +909,9 @@ const processSiriusXMEvent = () => {
       return;
     }
   }
+  const props = parseSimpleTable(data.commonEventProperties || []);
+  track(data.commonEventName, props, options);
+  data.gtmOnSuccess();
 };
 
 const processPinterestAdsEvent = () => {

--- a/template.tpl
+++ b/template.tpl
@@ -106,6 +106,10 @@ ___TEMPLATE_PARAMETERS___
         "displayValue": "Reddit Ads"
       },
       {
+        "value": "siriusXMEvent",
+        "displayValue": "SiriusXM"
+      },
+      {
         "value": "twitterAdsEvent",
         "displayValue": "Twitter Ads"
       },
@@ -380,6 +384,11 @@ ___TEMPLATE_PARAMETERS___
       {
         "paramName": "tagType",
         "paramValue": "redditAdsEvent",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
         "type": "EQUALS"
       },
       {
@@ -1792,6 +1801,20 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "TEXT",
+    "name": "siriusXMAppName",
+    "displayName": "Specific Application ID (optional)",
+    "help": "If multiple Application IDs are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application IDs)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
+    "type": "TEXT",
     "name": "stackAdaptConversionEventID",
     "displayName": "StackAdapt Conversion Event Unique ID",
     "simpleValueType": true,
@@ -2018,6 +2041,11 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
         "paramValue": "stackAdaptEvent",
         "type": "EQUALS"
       },
@@ -2194,6 +2222,10 @@ ___TEMPLATE_PARAMETERS___
             {
               "value": "pinterest-ads",
               "displayValue": "Pinterest Ads"
+            },
+            {
+              "value": "SiriusXM",
+              "displayValue": "SiriusXM"
             },
             {
               "value": "Twitter Ads",

--- a/template.tpl
+++ b/template.tpl
@@ -420,11 +420,12 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "paramName": "tagType",
-<<<<<<< HEAD
         "paramValue": "siriusXMEvent",
-=======
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
         "paramValue": "snapchatEvent",
->>>>>>> main
         "type": "EQUALS"
       },
       {
@@ -1836,6 +1837,20 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
+    "type": "TEXT",
+    "name": "siriusXMAppName",
+    "displayName": "Specific Application Name (optional)",
+    "help": "If multiple Application Names are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application Names)",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "siriusXMEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
     "type": "SELECT",
     "name": "snapchatEventName",
     "displayName": "Snapchat Event Name",
@@ -1973,20 +1988,6 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "CUSTOM_EVENT_5",
         "displayValue": "Custom Event 5"
-      }
-    ]
-  },
-  {
-    "type": "TEXT",
-    "name": "siriusXMAppName",
-    "displayName": "Specific Application Name (optional)",
-    "help": "If multiple Application Names are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application Names)",
-    "simpleValueType": true,
-    "enablingConditions": [
-      {
-        "paramName": "tagType",
-        "paramValue": "siriusXMEvent",
-        "type": "EQUALS"
       }
     ]
   },
@@ -2218,11 +2219,12 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "paramName": "tagType",
-<<<<<<< HEAD
         "paramValue": "siriusXMEvent",
-=======
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "tagType",
         "paramValue": "snapchatEvent",
->>>>>>> main
         "type": "EQUALS"
       },
       {
@@ -3819,3 +3821,5 @@ ___WEB_PERMISSIONS___
     "isRequired": true
   }
 ]
+
+

--- a/template.tpl
+++ b/template.tpl
@@ -3233,17 +3233,19 @@ const processStackAdaptEvent = () => {
 };
 
 const processSiriusXMEvent = () => {
-  const options = generateOptions("SiriusXM");
+  const siriusXMSDKKey = "SiriusXM";
+  let options = generateOptions(siriusXMSDKKey);
 
   if (data.siriusXMAppName) {
     const appNameToUse = data.siriusXMAppName.trim();
-    options = generateOptionsFromInstances("SiriusXM", appNameToUse, false);
+    options = generateOptionsFromInstances(siriusXMSDKKey, appNameToUse, false);
     if (options === undefined) {
       log("ERROR: Multiple SiriusXM App Names not supported: " + appNameToUse);
       data.gtmOnFailure();
       return;
     }
   }
+};
 
 const processPinterestAdsEvent = () => {
   const pinterestSDKKey = "pinterest-ads";

--- a/template.tpl
+++ b/template.tpl
@@ -3236,6 +3236,12 @@ const processSiriusXMEvent = () => {
   const siriusXMSDKKey = "SiriusXM";
   let options = generateOptions(siriusXMSDKKey);
 
+  if (!data.commonEventName) {
+    log("ERROR: Freshpaint SiriusXM GTM Template missing eventName");
+    data.gtmOnFailure();
+    return;
+  }
+
   if (data.siriusXMAppName) {
     const appNameToUse = data.siriusXMAppName.trim();
     options = generateOptionsFromInstances(siriusXMSDKKey, appNameToUse, false);
@@ -3245,6 +3251,9 @@ const processSiriusXMEvent = () => {
       return;
     }
   }
+  const props = parseSimpleTable(data.commonEventProperties || []);
+  track(data.commonEventName, props, options);
+  data.gtmOnSuccess();
 };
 
 const processPinterestAdsEvent = () => {

--- a/template.tpl
+++ b/template.tpl
@@ -1816,8 +1816,8 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "TEXT",
     "name": "siriusXMAppName",
-    "displayName": "Specific Application ID (optional)",
-    "help": "If multiple Application IDs are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application IDs)",
+    "displayName": "Specific Application Name (optional)",
+    "help": "If multiple Application Names are configured for the SiriusXM destination type, specify one to deliver to (if left blank, this event will be delivered to all configured Application Names)",
     "simpleValueType": true,
     "enablingConditions": [
       {
@@ -2524,6 +2524,9 @@ const processEvent = () => {
     case "stackAdaptEvent":
       processStackAdaptEvent();
       break;
+    case "siriusXMEvent":
+      processSiriusXMEvent();
+      break;
     case "pinterestAdsEvent":
       processPinterestAdsEvent();
       break;
@@ -3228,6 +3231,19 @@ const processStackAdaptEvent = () => {
     data.gtmOnFailure();
   }
 };
+
+const processSiriusXMEvent = () => {
+  const options = generateOptions("SiriusXM");
+
+  if (data.siriusXMAppName) {
+    const appNameToUse = data.siriusXMAppName.trim();
+    options = generateOptionsFromInstances("SiriusXM", appNameToUse, false);
+    if (options === undefined) {
+      log("ERROR: Multiple SiriusXM App Names not supported: " + appNameToUse);
+      data.gtmOnFailure();
+      return;
+    }
+  }
 
 const processPinterestAdsEvent = () => {
   const pinterestSDKKey = "pinterest-ads";


### PR DESCRIPTION
Adds in GTM tag for SiriusXM. Supports multi-config with an option to specify AppName to only send events to a particular instance.

<img width="690" height="565" alt="image" src="https://github.com/user-attachments/assets/413e0e32-b0b4-4f41-a8da-bbacfc0027bb" />
example generic event (confirmed this showed up in all siriusxm instances)

<img width="1438" height="487" alt="image" src="https://github.com/user-attachments/assets/6dacbcec-e16b-440e-9c90-3a7bd70f6d64" />
example of app name specific event (confirmed this did not show up in other instances)


## questions
this requires a property of `$siriusxm_aid` to be in the property fields of the given tag in GTM. it is also expected of the generic freshpaint js code (e.g., send `$siriusxm_aid`  in the body of custom event). i'm not sure if that's actually the behavior we want for customers.
 **update:** i think this is fine as is. the event processing code should pull from impression event, i just don't have testing data for that yet.

<img width="1432" height="731" alt="image" src="https://github.com/user-attachments/assets/570405b4-fdca-42ba-b23b-4f8f1a0e83c4" />
