### PR TITLE
Add support for 'customer type' option on GTM tag for Google CAPI. 

### DIFF
--- a/src/generatedParameters.json
+++ b/src/generatedParameters.json
@@ -1461,6 +1461,20 @@
     ]
   },
   {
+    "type": "TEXT",
+    "name": "googleAdsConversionApiCustomerType",
+    "displayName": "Customer Type (optional)",
+    "help": "Set to 'NEW' or 'RETURNING' to enable new vs. returning customer bidding in Google Ads. You can use a GTM variable (e.g. {{DLV - customer_type}}) to pass this dynamically. Your Google Ads account must be allowlisted by Google to use this feature.",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsConversionApiEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
     "type": "RADIO",
     "name": "impactEventTypeIdOrCodeSelector",
     "displayName": "Use event_type_id vs. event_type_code",

--- a/src/parameters/integrations/googleAdsConversionApi.ts
+++ b/src/parameters/integrations/googleAdsConversionApi.ts
@@ -23,6 +23,13 @@ export default function GoogleAdsConversionApiParams() {
       simpleValueType: true,
       enablingConditions: onlyForGoogleAdsConversionApiEvent,
     }),
+    text({
+      name: 'googleAdsConversionApiCustomerType',
+      displayName: 'Customer Type (optional)',
+      help: "Set to 'NEW' or 'RETURNING' to enable new vs. returning customer bidding in Google Ads. You can use a GTM variable (e.g. {{DLV - customer_type}}) to pass this dynamically. Your Google Ads account must be allowlisted by Google to use this feature.",
+      simpleValueType: true,
+      enablingConditions: onlyForGoogleAdsConversionApiEvent,
+    }),
     commonEventProperties(onlyForGoogleAdsConversionApiEvent),
   ];
 }

--- a/src/web.js
+++ b/src/web.js
@@ -813,6 +813,10 @@ const processGoogleAdsConversionApiEvent = () => {
     props.ctname = data.googleAdsConversionApiConversionName;
   }
 
+  if (data.googleAdsConversionApiCustomerType) {
+    props.customer_type = data.googleAdsConversionApiCustomerType;
+  }
+
   track(data.commonEventName, props, options);
 
   data.gtmOnSuccess();

--- a/template.tpl
+++ b/template.tpl
@@ -1490,6 +1490,20 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
+    "type": "TEXT",
+    "name": "googleAdsConversionApiCustomerType",
+    "displayName": "Customer Type (optional)",
+    "help": "Set to 'NEW' or 'RETURNING' to enable new vs. returning customer bidding in Google Ads. You can use a GTM variable (e.g. {{DLV - customer_type}}) to pass this dynamically. Your Google Ads account must be allowlisted by Google to use this feature.",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "tagType",
+        "paramValue": "googleAdsConversionApiEvent",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
     "type": "RADIO",
     "name": "impactEventTypeIdOrCodeSelector",
     "displayName": "Use event_type_id vs. event_type_code",
@@ -3258,6 +3272,10 @@ const processGoogleAdsConversionApiEvent = () => {
 
   if (data.googleAdsConversionApiConversionName) {
     props.ctname = data.googleAdsConversionApiConversionName;
+  }
+
+  if (data.googleAdsConversionApiCustomerType) {
+    props.customer_type = data.googleAdsConversionApiCustomerType;
   }
 
   track(data.commonEventName, props, options);


### PR DESCRIPTION
This value gets pushed into GTM as a data layer variable by the customer. It can be added dynamically in the GTM tag. The new/returning logic is determined by the customer. 