### PR TITLE
Drop blank properties to prevent unintentional Identify calls

### DIFF
--- a/src/web.js
+++ b/src/web.js
@@ -14,6 +14,28 @@ const setDefaultConsentState = require('setDefaultConsentState');
 const gtagSet = require('gtagSet');
 const getCookieValues = require('getCookieValues');
 
+// A property name/value is considered blank when it is undefined, null, or an
+// empty string. Note: this intentionally does NOT treat 0 or false as blank so
+// legitimate numeric/boolean values are kept.
+function isBlank(value) {
+  return value === undefined || value === null || value === "";
+}
+
+// Returns a copy of obj with fully-blank entries (blank key AND blank value)
+// removed, leaving named properties — even empty-valued ones — intact so they
+// stay visible in the payload for troubleshooting. Keys are always strings, so
+// a blank key can only be the empty string.
+function dropBlankProps(obj) {
+  const cleaned = {};
+  for (let key in obj) {
+    if (key === "" && isBlank(obj[key])) {
+      continue;
+    }
+    cleaned[key] = obj[key];
+  }
+  return cleaned;
+}
+
 function parseSimpleTable(inputProps) {
   const props = {};
   for (let prop of inputProps) {
@@ -441,7 +463,9 @@ const processGA4Event = () => {
 
   const userPropsFromVar = getUserPropsFromGoogleTagEventSettingsVar(data.ga4EventPropsVariable);
   const userProps = parseSimpleTable(data.commonUserProperties || []);
-  const allUserProps = mergeObj(userPropsFromVar, userProps);
+  // Drop fully-blank rows so a phantom {"": ""} property doesn't make the
+  // emptiness check below fire an unintentional Identify call.
+  const allUserProps = dropBlankProps(mergeObj(userPropsFromVar, userProps));
   if (!objectIsEmpty(allUserProps)) {
     identify(undefined, allUserProps, options);
   }

--- a/template.tpl
+++ b/template.tpl
@@ -2608,6 +2608,28 @@ const setDefaultConsentState = require('setDefaultConsentState');
 const gtagSet = require('gtagSet');
 const getCookieValues = require('getCookieValues');
 
+// A property name/value is considered blank when it is undefined, null, or an
+// empty string. Note: this intentionally does NOT treat 0 or false as blank so
+// legitimate numeric/boolean values are kept.
+function isBlank(value) {
+  return value === undefined || value === null || value === "";
+}
+
+// Returns a copy of obj with fully-blank entries (blank key AND blank value)
+// removed, leaving named properties — even empty-valued ones — intact so they
+// stay visible in the payload for troubleshooting. Keys are always strings, so
+// a blank key can only be the empty string.
+function dropBlankProps(obj) {
+  const cleaned = {};
+  for (let key in obj) {
+    if (key === "" && isBlank(obj[key])) {
+      continue;
+    }
+    cleaned[key] = obj[key];
+  }
+  return cleaned;
+}
+
 function parseSimpleTable(inputProps) {
   const props = {};
   for (let prop of inputProps) {
@@ -3035,7 +3057,9 @@ const processGA4Event = () => {
 
   const userPropsFromVar = getUserPropsFromGoogleTagEventSettingsVar(data.ga4EventPropsVariable);
   const userProps = parseSimpleTable(data.commonUserProperties || []);
-  const allUserProps = mergeObj(userPropsFromVar, userProps);
+  // Drop fully-blank rows so a phantom {"": ""} property doesn't make the
+  // emptiness check below fire an unintentional Identify call.
+  const allUserProps = dropBlankProps(mergeObj(userPropsFromVar, userProps));
   if (!objectIsEmpty(allUserProps)) {
     identify(undefined, allUserProps, options);
   }


### PR DESCRIPTION
Drop fully-blank rows from GA4 user properties to prevent unintentional Identify calls

Fully-blank GA4 user property rows (empty name and value) produced a phantom empty-keyed property {"": ""}. 

Because the GA4 auto-Identify only fires when the user-property object is non-empty (objectIsEmpty), that phantom key flipped the guard and triggered unintentional Identify calls.

Fix: drop fully-blank entries from the merged GA4 user-props object before the emptiness check. Scoped to the GA4 Identify path only - event properties and named empty-valued props (e.g. foo: "") are left untouched, so a dynamic prop that resolves empty still shows up for troubleshooting. 0 and false are preserved.

Helpdesk thread: https://freshpaint-io.slack.com/archives/C01T4F9FWHY/p1781807568484709